### PR TITLE
Tidy sql

### DIFF
--- a/model/bid.js
+++ b/model/bid.js
@@ -147,7 +147,8 @@ const highestCurrentBid = async (driver, date, time, origin, destination, db) =>
       AND b.date = $2
       AND b.time = $3
       AND b.origin = $4
-      AND b.destination = $5;`,
+      AND b.destination = $5
+      AND b.bidstatus = 'pending';`,
       [driver, new Date(date), time, origin, destination]
     )
     .then(result => {
@@ -219,7 +220,9 @@ const updateBidStatus = async (
     })
 }
 
-
+/*
+List bids available for driver to confirm
+ */
 const listBidsForRide = async (driver, date, time, origin, destination, db) => {
   return db
     .any(
@@ -231,6 +234,7 @@ const listBidsForRide = async (driver, date, time, origin, destination, db) => {
         AND b.time = $3
         AND b.origin = $4
         AND b.destination = $5
+        AND b.bidstatus = 'pending'
       ORDER BY b.bidAmount DESC;
       `,
       [driver, new Date(date), time, origin, destination]

--- a/model/bid.js
+++ b/model/bid.js
@@ -204,15 +204,7 @@ const updateBidStatus = async (
         AND time = $4 
         AND origin = $5 
         AND destination = $6;
-        
-        UPDATE bid
-        SET bidStatus = 'unsuccessful' 
-        WHERE bidder <> $1 
-        AND driver = $2 
-        AND date = $3 
-        AND time = $4 
-        AND origin = $5
-        AND destination = $6;`,
+        `,
       [successfulBidder, driver, date, time, origin, destination]
     )
     .then(() => {

--- a/model/db.js
+++ b/model/db.js
@@ -59,24 +59,7 @@ async function initDb() {
     REFERENCES advertisedCarRide(driver, date, time, origin, destination),
     PRIMARY KEY(bidder, driver, date, time, origin, destination)
   );
-  
-  --
-  -- Convenience view to list max amount of car seats with current car seats
-  -- already occupied by successful bidders.
-  --
-  CREATE VIEW car_rides_with_capacity 
-  (driver, date, time, origin, destination, maxcapacity) 
-  AS SELECT b.driver, b.date, b.time, b.origin, b.destination ,uCar.numseats, count(*)
-	FROM bid b, advertisedCarRide aCar, userOwnsACar uCar
-	WHERE b.bidstatus = 'successful'
-	AND aCar.date = b.date
-	AND aCar.driver = b.driver
-	AND aCar.time = b.time
-	AND aCar.origin = b.origin
-	AND aCar.destination = b.destination
-	AND aCar.car = uCar.licensePlate
-	group by b.driver, b.date, b.time, b.origin, b.destination, uCar.numseats
-	order by b.driver,b.date,b.time,b.origin,b.destination;  
+
   COMMIT;`
 
   return db

--- a/model/db.js
+++ b/model/db.js
@@ -59,7 +59,24 @@ async function initDb() {
     REFERENCES advertisedCarRide(driver, date, time, origin, destination),
     PRIMARY KEY(bidder, driver, date, time, origin, destination)
   );
-
+  
+  --
+  -- Convenience view to list max amount of car seats with current car seats
+  -- already occupied by successful bidders.
+  --
+  CREATE VIEW car_rides_with_capacity 
+  (driver, date, time, origin, destination, maxcapacity) 
+  AS SELECT b.driver, b.date, b.time, b.origin, b.destination ,uCar.numseats, count(*)
+	FROM bid b, advertisedCarRide aCar, userOwnsACar uCar
+	WHERE b.bidstatus = 'successful'
+	AND aCar.date = b.date
+	AND aCar.driver = b.driver
+	AND aCar.time = b.time
+	AND aCar.origin = b.origin
+	AND aCar.destination = b.destination
+	AND aCar.car = uCar.licensePlate
+	group by b.driver, b.date, b.time, b.origin, b.destination, uCar.numseats
+	order by b.driver,b.date,b.time,b.origin,b.destination;  
   COMMIT;`
 
   return db

--- a/model/db.js
+++ b/model/db.js
@@ -66,6 +66,8 @@ async function initDb() {
   -- Convenience view to be used in one of the queries to showcase use of views
   -- Other places where this view could be used but are not used is deliberate
   -- to showcase other uses of sql
+  -- TODO: Rename to reflect that this does not include car rides without
+  -- successful bids as intended
   --
   CREATE VIEW car_rides_with_capacity 
   (driver, date, time, origin, destination, maxcapacity, currcapacity) 

--- a/model/db.js
+++ b/model/db.js
@@ -59,6 +59,25 @@ async function initDb() {
     REFERENCES advertisedCarRide(driver, date, time, origin, destination),
     PRIMARY KEY(bidder, driver, date, time, origin, destination)
   );
+  
+  --
+  -- Convenience view to be used in one of the queries to showcase use of views
+  -- Other places where this view could be used but are not used is deliberate
+  -- to showcase other uses of sql
+  --
+  CREATE VIEW car_rides_with_capacity 
+  (driver, date, time, origin, destination, maxcapacity, currcapacity) 
+  AS SELECT b.driver, b.date, b.time, b.origin, b.destination ,uCar.numseats, count(*)
+	FROM bid b, advertisedCarRide aCar, userOwnsACar uCar
+	  WHERE b.bidstatus = 'successful'
+	  AND aCar.date = b.date
+	  AND aCar.driver = b.driver
+	  AND aCar.time = b.time
+	  AND aCar.origin = b.origin
+	  AND aCar.destination = b.destination
+	  AND aCar.car = uCar.licensePlate
+	  group by b.driver, b.date, b.time, b.origin, b.destination, uCar.numseats
+	  order by b.driver,b.date,b.time,b.origin,b.destination;  
 
   COMMIT;`
 
@@ -218,7 +237,8 @@ async function createFunctionsAndTriggers() {
 async function deinitDb() {
   const query = `
   BEGIN;
-
+  
+  DROP VIEW IF EXISTS car_rides_with_capacity;
   DROP TABLE IF EXISTS bid;
   DROP TABLE IF EXISTS advertisedCarRide;
   DROP TABLE IF EXISTS userOwnsACar;

--- a/model/ride.js
+++ b/model/ride.js
@@ -172,14 +172,19 @@ const listPendingRidesForDriver = async (user, db) => {
   return db
     .any(
       `
-    SELECT a.driver, a.date, a.time, a.origin, a.destination, a.car FROM advertisedCarRide a
-    LEFT OUTER JOIN bid b ON a.driver = b.driver
-      AND a.date = b.date
-      AND a.time = b.time
-      AND a.origin = b.origin
-      AND a.destination = b.destination
-    WHERE a.driver = $1 AND (b.bidStatus = 'pending' OR b.bidStatus IS NULL)
-    GROUP BY a.driver, a.date, a.time, a.origin, a.destination;
+      SELECT DISTINCT a.driver, a.date, a.time, a.origin, a.destination, a.car 
+      FROM advertisedCarRide a, bid b
+      WHERE a.driver = $1
+      AND NOT EXISTS(
+        SELECT 1
+        FROM car_rides_with_capacity c
+        WHERE a.driver = c.driver
+        AND a.date = c.date
+        AND a.time = c.time
+        AND a.origin = c.origin
+        AND a.destination = c.destination
+        AND c.currcapacity >= c.maxcapacity)
+      ORDER BY a.driver, a.date, a.time, a.origin, a.destination;
     `,
       [user]
     )

--- a/model/ride.js
+++ b/model/ride.js
@@ -173,7 +173,7 @@ const listPendingRidesForDriver = async (user, db) => {
     .any(
       `
       SELECT DISTINCT a.driver, a.date, a.time, a.origin, a.destination, a.car 
-      FROM advertisedCarRide a, bid b
+      FROM advertisedCarRide a
       WHERE 
       -- This ride is advertised by the driver
       a.driver = $1 
@@ -183,6 +183,7 @@ const listPendingRidesForDriver = async (user, db) => {
               AND a.time > current_time)
           )
       -- This ride has not reached maximum capacity
+      -- This condition makes checking for bidstatus redundant
       AND NOT EXISTS( 
         SELECT 1
         FROM car_rides_with_capacity c

--- a/model/ride.js
+++ b/model/ride.js
@@ -212,6 +212,5 @@ module.exports = {
   listConfirmedRidesForDriver,
   listPendingRidesForDriver,
   listCarsUserOwns,
-  delAdvertisedRide,
   delAdvertisedRide
 }


### PR DESCRIPTION
# Bug fixes for sql quaries

## highestCurrentBid:
- Now only displays highest current bid for `pending` bids

## updateBidStatus:
- No longer sets other bids as unsuccessful, the proper logic is left to the trigger to handle

## listBidsForRide
- Now only displays `pending` bids

## car_rides_with_capacity 
- New view to support the proper listing of pending rides

## listPendingRidesForDriver
- Pending rides now check for the following conditions:
  - This ride is advertised by the driver
  - This ride is not overdue
  - This ride has not reached maximum capacity

## misc
removed duplicate code


